### PR TITLE
UDPReceiver.java: Ignore any updates that I sent

### DIFF
--- a/src/net/dumbinter/netclip/UDPReceiver.java
+++ b/src/net/dumbinter/netclip/UDPReceiver.java
@@ -4,18 +4,18 @@ import java.io.IOException;
 import java.net.DatagramPacket;
 import java.net.DatagramSocket;
 import java.net.InetAddress;
+import java.net.NetworkInterface;
 import java.net.SocketException;
 import java.net.UnknownHostException;
 
-public class UDPReceiver implements Runnable{
-	
+public class UDPReceiver implements Runnable {
 	DatagramSocket socket;
-    int port;
+	int port;
 	
 	public UDPReceiver(int port) {
 		this.port=port;
-	    try {
-	    	socket = new DatagramSocket(port, InetAddress.getByName("0.0.0.0"));
+		try {
+			socket = new DatagramSocket(port, InetAddress.getByName("0.0.0.0"));
 			socket.setBroadcast(true);
 		} catch (SocketException | UnknownHostException e) {
 			// TODO Auto-generated catch block
@@ -27,14 +27,18 @@ public class UDPReceiver implements Runnable{
 		System.out.println("Listening for input");
 		while(true) { 
 			byte[] recvBuf = new byte[14];
-	        DatagramPacket packet = new DatagramPacket(recvBuf, recvBuf.length);
-	        try {
+			DatagramPacket packet = new DatagramPacket(recvBuf, recvBuf.length);
+			try {
 				socket.receive(packet);
-				System.out.println("Received from: " + packet.getAddress().getHostAddress() + " [" + new String(packet.getData()) + "]");
-				if("NETCLIP_NOTIFY".equals(new String(packet.getData()))) {
-					System.out.println("Fetching Clipboard Data via TCP");
-					NetClipboard.setData(TCPClient.fetchClipboard(packet.getAddress(),port));
-					NetClipboard.update();
+				final InetAddress addr = packet.getAddress();
+				System.out.println("Received from: " + addr.getHostAddress() + " [" + new String(packet.getData()) + "]");
+				// Only process the message if we didn't send it
+				if (NetworkInterface.getByInetAddress(addr) == null) {
+					if ("NETCLIP_NOTIFY".equals(new String(packet.getData()))) {
+						System.out.println("Fetching Clipboard Data via TCP");
+						NetClipboard.setData(TCPClient.fetchClipboard(packet.getAddress(),port));
+						NetClipboard.update();
+					}
 				}
 				
 			} catch (IOException e) {
@@ -43,6 +47,4 @@ public class UDPReceiver implements Runnable{
 			}
 		}
 	}
-
-
 }


### PR DESCRIPTION
On Windows especially, applications store additional formats/flavours in the clipboard in addition to the string format/flavour.
If we process our own clipboard updates, we overwrite the clipboard and the non-string formats/flavours are lost. This breaks cut-and-paste in some applications, e.g., OneNote.
So just ignore any updates than we sent, since our own clipboard is already up-to-date.

Also fixed some indentation issues.
